### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,6 +4,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/listitems/security/code-scanning/2](https://github.com/Adam-Robson/listitems/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it primarily reads repository contents and does not appear to require write access. Therefore, the `permissions` block should be set to `contents: read`. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
